### PR TITLE
Kg exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ subscribe to the `ended` event:
 ```javascript
 observer = new ObservableProcess('my-server')
 observer.on 'ended', (exitCode) => {
-  // the process has ended
+  // the process has ended here
+  // you can also access the exit code via observer.exitCode
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ subscribe to the `ended` event:
 ```javascript
 observer = new ObservableProcess('my-server')
 observer.on 'ended', (exitCode) => {
-  // the server has ended
+  // the process has ended
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ observer.kill()
 ```
 
 To let ObservableProcess notify you when a process ended,
-provide it a callback via the `onExit` parameter:
+subscribe to the `ended` event:
 
 ```javascript
-observer = new ObservableProcess('my-server', onExit: function() {
-  // here the server has ended
-});
+observer = new ObservableProcess('my-server')
+observer.on 'ended', (exitCode) => {
+  // the server has ended
+}
 ```
 
 

--- a/features/ending-processes.feature
+++ b/features/ending-processes.feature
@@ -12,5 +12,6 @@ Feature: Recognizing process termination
     Given I spawn an interactive process
     Then the processes "ended" property is false
     When it ends
-    Then the on-exit event is emitted
+    Then the on-exit event is emitted with the exit code 1
     And the processes "ended" property is true
+    And the exit code is set in the .exitCode property

--- a/features/example-apps/interactive
+++ b/features/example-apps/interactive
@@ -6,4 +6,4 @@
 console.log 'running'
 process.stdin.on 'data', ->
   console.log 'ended'
-  process.exit!
+  process.exit 1

--- a/features/steps/steps.ls
+++ b/features/steps/steps.ls
@@ -30,7 +30,7 @@ module.exports = ->
   @Given /^I spawn an interactive process$/, (done) ->
     @on-exit-called = no
     @observable-process = new ObservableProcess "features/example-apps/interactive"
-      ..on 'ended', ~> @on-exit-called = yes
+      ..on 'ended', (@exit-code) ~> @on-exit-called = yes
       ..wait "running", done
 
 
@@ -92,8 +92,13 @@ module.exports = ->
 
 
 
-  @Then /^the on\-exit event is emitted/, (done) ->
-    wait-until (~> @on-exit-called is yes), ->
+  @Then /^the exit code is set in the \.exitCode property$/ ->
+    expect(@observable-process.exit-code).to.equal 1
+
+
+  @Then /^the on\-exit event is emitted with the exit code (\d+)$/, (expected-exit-code, done) ->
+    wait-until (~> @on-exit-called is yes), ~>
+      expect(@exit-code).to.equal parse-int(expected-exit-code)
       done!
 
 

--- a/src/observable-process.ls
+++ b/src/observable-process.ls
@@ -56,13 +56,13 @@ class ObservableProcess extends EventEmitter
     @process.kill!
 
 
-  on-close: (err) ~>
+  on-close: (@exit-code) ~>
     | @killed  =>  return
     @ended = yes
     if @verbose
       @console?.log 'PROCESS ENDED'
-      @console?.log "\nEXIT CODE: #{err}"
-    @emit 'ended'
+      @console?.log "\nEXIT CODE: #{@exit-code}"
+    @emit 'ended', @exit-code
 
 
 


### PR DESCRIPTION
@mcharawi @alexdavid 

Provides the exit code in the `ended` event and as an attribute of the ObservableProcess instance